### PR TITLE
feat: create glossary table and glossary_project pivot table

### DIFF
--- a/app/Filament/Resources/GlossaryResource.php
+++ b/app/Filament/Resources/GlossaryResource.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\GlossaryResource\Pages;
+use App\Filament\Resources\GlossaryResource\RelationManagers;
+use App\Models\Glossary;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class GlossaryResource extends Resource
+{
+    protected static ?string $model = Glossary::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\CheckboxList::make('projects')
+                    ->relationship('projects', 'name')
+                    ->columns(2)
+                    ->label('Associated Projects'),
+                Forms\Components\TextInput::make('name')
+                    ->required(),
+                Forms\Components\Select::make('source_language')
+                    ->options([
+                        'en' => 'English',
+                        'fr' => 'French',
+                        'de' => 'German',
+                        'es' => 'Spanish',
+                        'it' => 'Italian',
+                        'pt' => 'Portuguese',
+                        'zh' => 'Chinese',
+                        'ja' => 'Japanese',
+                        'ru' => 'Russian',
+                    ])
+                    ->required(),
+                Forms\Components\Select::make('target_language')
+                    ->options([
+                        'en' => 'English',
+                        'fr' => 'French',
+                        'de' => 'German',
+                        'es' => 'Spanish',
+                        'it' => 'Italian',
+                        'pt' => 'Portuguese',
+                        'zh' => 'Chinese',
+                        'ja' => 'Japanese',
+                        'ru' => 'Russian',
+                    ])
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name'),
+                Tables\Columns\TextColumn::make('source_language'),
+                Tables\Columns\TextColumn::make('target_language'),
+                Tables\Columns\TextColumn::make('projects.name')
+                    ->label('Project(s)')
+                    ->formatStateUsing(fn ($state, $record) => 
+                        $record->projects->isNotEmpty()
+                            ? $record->projects->pluck('name')->join(', ')
+                            : '—'
+                    ),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGlossaries::route('/'),
+            //'create' => Pages\CreateGlossary::route('/create'),
+            //'edit' => Pages\EditGlossary::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/GlossaryResource/Pages/CreateGlossary.php
+++ b/app/Filament/Resources/GlossaryResource/Pages/CreateGlossary.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\GlossaryResource\Pages;
+
+use App\Filament\Resources\GlossaryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateGlossary extends CreateRecord
+{
+    protected static string $resource = GlossaryResource::class;
+}

--- a/app/Filament/Resources/GlossaryResource/Pages/EditGlossary.php
+++ b/app/Filament/Resources/GlossaryResource/Pages/EditGlossary.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\GlossaryResource\Pages;
+
+use App\Filament\Resources\GlossaryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGlossary extends EditRecord
+{
+    protected static string $resource = GlossaryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/GlossaryResource/Pages/ListGlossaries.php
+++ b/app/Filament/Resources/GlossaryResource/Pages/ListGlossaries.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\GlossaryResource\Pages;
+
+use App\Filament\Resources\GlossaryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGlossaries extends ListRecords
+{
+    protected static string $resource = GlossaryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -30,12 +30,13 @@ class ProjectResource extends Resource
                 ->preload()
                 ->required(),
                 Forms\Components\TextInput::make('name')
+                    ->label('Project Name')
                     ->required()
                     ->maxLength(255),
                 Forms\Components\Select::make('status')
                     ->required()
                     ->options([
-                        'pending' => 'Pending',
+                        'not_started' => 'Not Started',
                         'in_progress' => 'In Progress',
                         'completed' => 'Completed',
                         'cancelled' => 'Cancelled',
@@ -51,6 +52,7 @@ class ProjectResource extends Resource
                 Forms\Components\Textarea::make('instructions')
                     ->maxLength(65535),
                 Forms\Components\Select::make('created_by')
+                    ->label('Created By')
                     ->required()
                     ->relationship('user', 'name'),
             ]);

--- a/app/Models/Glossary.php
+++ b/app/Models/Glossary.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Glossary extends Model
+{
+    protected $fillable = [
+        'tenant_id',
+        'name',
+        'source_language',
+        'target_language',
+    ];
+    
+    // public function terms(): HasMany
+    // {
+    //     return $this->hasMany(GlossaryTerm::class);
+    // }
+
+    public function projects(): BelongsToMany
+    {
+        return $this->belongsToMany(Project::class, 'glossary_project');
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -42,6 +42,11 @@ class Project extends Model
         return $this->hasMany(File::class);
     }
 
+    public function glossaries()
+    {
+        return $this->belongsToMany(Glossary::class, 'glossary_project');
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('tenant', function (Builder $query) {

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -40,6 +40,11 @@ class Tenant extends Model
     {
         return $this->hasMany(File::class);
     }
+    
+    public function glossaries(): HasMany
+    {
+        return $this->hasMany(Glossary::class);
+    }
 }
 
         

--- a/database/migrations/2025_07_17_163606_create_glossaries_table.php
+++ b/database/migrations/2025_07_17_163606_create_glossaries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    // Run the migrations.
+    public function up(): void
+    {
+        Schema::create('glossaries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->string('source_language');
+            $table->string('target_language');
+            $table->timestamps();
+        });
+    }
+
+    // Reverse the migrations.
+    public function down(): void
+    {
+        Schema::dropIfExists('glossaries');
+    }
+};

--- a/database/migrations/2025_07_17_164748_create_glossary_project_table.php
+++ b/database/migrations/2025_07_17_164748_create_glossary_project_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('glossary_project', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->onDelete('cascade');
+            $table->foreignId('glossary_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('glossary_project');
+    }
+};


### PR DESCRIPTION
- Added `glossaries` table with name, source_language, and target_language fields
- Linked glossaries to tenants via foreign key
- Created `glossary_project` pivot table to support many-to-many relationship between glossaries and projects
- Defined Eloquent relationships in `Glossary` and `Project` models
- Updated GlossaryResource form and table to include project association