### PR TITLE
feat: add terms migration and model for glossary entries

### DIFF
--- a/app/Filament/Resources/TermResource.php
+++ b/app/Filament/Resources/TermResource.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TermResource\Pages;
+use App\Filament\Resources\TermResource\RelationManagers;
+use App\Models\Term;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class TermResource extends Resource
+{
+    protected static ?string $model = Term::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('source_term')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('target_term')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\Select::make('glossary_id')
+                    ->relationship('glossary', 'name')
+                    ->required(),
+                Forms\Components\Select::make('type')
+                    ->options([
+                        'word' => 'Word',
+                        'phrase' => 'Phrase',
+                        'acronym' => 'Acronym',
+                        'abbreviation' => 'Abbreviation',
+                        'idiom' => 'Idiom',
+                        'collocation' => 'Collocation',
+                    ])
+                    ->required(),
+                Forms\Components\Select::make('part_of_speech')
+                    ->options([
+                        'noun' => 'Noun',
+                        'verb' => 'Verb',
+                        'adjective' => 'Adjective',
+                        'adverb' => 'Adverb',
+                        'pronoun' => 'Pronoun',
+                        'preposition' => 'Preposition',
+                        'conjunction' => 'Conjunction',
+                        'interjection' => 'Interjection',
+                    ])
+                    ->required(),
+                Forms\Components\Select::make('domain')
+                    ->options([
+                        'general' => 'General',
+                        'technical' => 'Technical',
+                        'legal' => 'Legal',
+                        'medical' => 'Medical',
+                        'financial' => 'Financial',
+                        'IT' => 'IT',
+                        'marketing' => 'Marketing',
+                        'scientific' => 'Scientific',
+                        'education' => 'Education',
+                        'engineering' => 'Engineering',
+                    ])
+                    ->required(),
+                Forms\Components\Textarea::make('context')
+                    ->rows(3),
+                Forms\Components\Select::make('created_by')
+                    ->label('Created By')
+                    ->relationship('user', 'name')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('source_term'),
+                Tables\Columns\TextColumn::make('target_term'),
+                Tables\Columns\TextColumn::make('glossary.name')->label('Glossary'),
+                Tables\Columns\TextColumn::make('type')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('part_of_speech')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('domain')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('context')
+                    ->badge(),
+                Tables\Columns\TextColumn::make('user.name')->label('Created By'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('glossary_id')
+                    ->relationship('glossary', 'name'),
+                Tables\Filters\SelectFilter::make('type')
+                    ->options([
+                        'word' => 'Word',
+                        'phrase' => 'Phrase',
+                        'acronym' => 'Acronym',
+                        'abbreviation' => 'Abbreviation',
+                        'idiom' => 'Idiom',
+                        'collocation' => 'Collocation',
+                    ]),
+                Tables\Filters\SelectFilter::make('part_of_speech')
+                    ->options([     
+                        'noun' => 'Noun',
+                        'verb' => 'Verb',
+                        'adjective' => 'Adjective',
+                        'adverb' => 'Adverb',
+                        'pronoun' => 'Pronoun',
+                        'preposition' => 'Preposition',
+                        'conjunction' => 'Conjunction',
+                        'interjection' => 'Interjection',
+                    ]),
+                Tables\Filters\SelectFilter::make('domain')
+                    ->options([
+                        'general' => 'General',
+                        'technical' => 'Technical',
+                        'legal' => 'Legal',
+                        'medical' => 'Medical',
+                        'financial' => 'Financial',
+                        'IT' => 'IT',
+                        'marketing' => 'Marketing',
+                        'scientific' => 'Scientific',
+                        'education' => 'Education',
+                        'engineering' => 'Engineering',
+                    ]),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTerms::route('/'),
+            //'create' => Pages\CreateTerm::route('/create'),
+            //'edit' => Pages\EditTerm::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TermResource/Pages/CreateTerm.php
+++ b/app/Filament/Resources/TermResource/Pages/CreateTerm.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\TermResource\Pages;
+
+use App\Filament\Resources\TermResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTerm extends CreateRecord
+{
+    protected static string $resource = TermResource::class;
+}

--- a/app/Filament/Resources/TermResource/Pages/EditTerm.php
+++ b/app/Filament/Resources/TermResource/Pages/EditTerm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\TermResource\Pages;
+
+use App\Filament\Resources\TermResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTerm extends EditRecord
+{
+    protected static string $resource = TermResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/TermResource/Pages/ListTerms.php
+++ b/app/Filament/Resources/TermResource/Pages/ListTerms.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\TermResource\Pages;
+
+use App\Filament\Resources\TermResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTerms extends ListRecords
+{
+    protected static string $resource = TermResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Glossary.php
+++ b/app/Models/Glossary.php
@@ -15,10 +15,10 @@ class Glossary extends Model
         'target_language',
     ];
     
-    // public function terms(): HasMany
-    // {
-    //     return $this->hasMany(GlossaryTerm::class);
-    // }
+    public function terms(): HasMany
+    {
+        return $this->hasMany(GlossaryTerm::class);
+    }
 
     public function projects(): BelongsToMany
     {

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -45,6 +45,11 @@ class Tenant extends Model
     {
         return $this->hasMany(Glossary::class);
     }
+
+    public function terms(): HasMany
+    {
+        return $this->hasMany(Term::class);
+    }
 }
 
         

--- a/app/Models/Term.php
+++ b/app/Models/Term.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Term extends Model
+{
+    protected $fillable = [
+        'tenant_id',
+        'glossary_id',
+        'source_term',
+        'target_term',
+        'type',
+        'part_of_speech',
+        'domain',
+        'context',
+        'created_by',
+    ];
+
+    public function glossary()
+    {
+        return $this->belongsTo(Glossary::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+    
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/database/migrations/2025_07_17_190057_create_terms_table.php
+++ b/database/migrations/2025_07_17_190057_create_terms_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    // Run the migrations.
+    public function up(): void
+    {
+        Schema::create('terms', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->onDelete('cascade');
+            $table->foreignId('glossary_id')->constrained()->onDelete('cascade');
+            $table->string('source_term');
+            $table->string('target_term');
+            $table->enum('type', ['word', 'phrase', 'acronym', 'abbreviation', 'idiom', 'collocation'])->nullable();
+            $table->enum ('part_of_speech', ['noun', 'verb', 'adjective', 'adverb', 'pronoun', 'preposition', 'conjunction', 'interjection'])->nullable();
+            $table->enum('domain', ['general', 'technical', 'legal', 'medical', 'financial', 'IT', 'marketing', 'scientific', 'education', 'engineering'])->nullable();
+            $table->text('context')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    // Reverse the migrations.
+    public function down(): void
+    {
+        Schema::dropIfExists('terms');
+    }
+};


### PR DESCRIPTION
- Created the  table with fields for , , , , , and .
- Added foreign keys to , , and  to maintain relational integrity.
- Included enums for  and  to categorize terms accurately.
- Set up cascade and null-on-delete rules for proper cleanup.
- Prepared groundwork for managing glossary terms linked to projects and tenants.